### PR TITLE
recovery:updater: Changes to support 32->64 bit upgrades

### DIFF
--- a/updater/Android.mk
+++ b/updater/Android.mk
@@ -58,8 +58,11 @@ LOCAL_C_INCLUDES += $(LOCAL_PATH)/..
 # any subsidiary static libraries required for your registered
 # extension libs.
 
+ifeq ($(TARGET_ARCH),arm64)
+inc := $(call intermediates-dir-for,PACKAGING,updater_extensions,,,32)/register.inc
+else
 inc := $(call intermediates-dir-for,PACKAGING,updater_extensions)/register.inc
-
+endif
 # Encode the value of TARGET_RECOVERY_UPDATER_LIBS into the filename of the dependency.
 # So if TARGET_RECOVERY_UPDATER_LIBS is changed, a new dependency file will be generated.
 # Note that we have to remove any existing depency files before creating new one,
@@ -79,14 +82,18 @@ $(inc) : $(inc_dep_file)
 	$(hide) echo "void RegisterDeviceExtensions() {" >> $@
 	$(hide) $(foreach lib,$(libs),echo "  Register_$(lib)();" >> $@;)
 	$(hide) echo "}" >> $@
-
+ifeq ($(TARGET_ARCH),arm64)
+$(call intermediates-dir-for,EXECUTABLES,updater,,,32)/updater.o : $(inc)
+else
 $(call intermediates-dir-for,EXECUTABLES,updater)/updater.o : $(inc)
+endif
 LOCAL_C_INCLUDES += $(dir $(inc))
 
 inc :=
 inc_dep_file :=
 
 LOCAL_MODULE := updater
+LOCAL_32_BIT_ONLY := true
 
 LOCAL_FORCE_STATIC_EXECUTABLE := true
 


### PR DESCRIPTION
We now support upgrading from 32 to 64 bit builds. The check for device to
package compatibility now takes into account if the product name on the
device vs the product name on the upgrade build differs only by the _32
or _64 trailing chars. In addition we also force compile the updater binary
as 32 bit executable so that it can run on the 32 bit build we are upgrading
from.

Change-Id: I51bdf948650b9c3b61cfac7142422b7325270940
